### PR TITLE
update nginx module tag and helm chart version

### DIFF
--- a/hashicorp-vault/main.tf
+++ b/hashicorp-vault/main.tf
@@ -230,11 +230,11 @@ module "certificate" {
 }
 
 module "nginx_ingress" {
-  source = "git::https://github.com/Azure-Terraform/terraform-azurerm-kubernetes-nginx-ingress.git?ref=v1.0.0"
+  source = "git::https://github.com/Azure-Terraform/terraform-azurerm-kubernetes-nginx-ingress.git?ref=v1.2.0"
 
   providers  = { helm = helm.aks }
 
-  helm_chart_version = "1.40.1"
+  helm_chart_version = "3.4.1"
   helm_release_name = "nginx-ingress-vault"
 
   kubernetes_namespace        = "hashicorp-vault"


### PR DESCRIPTION
**Error:** looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: failed to fdex.yaml : 403 Forbidden for module nginx_ingress

**Fix:** Updated the ingress module tag and the helm chart version